### PR TITLE
New plugin option "headerText: Function" to change the default header text retrieval.

### DIFF
--- a/dist/jquery.toc.js
+++ b/dist/jquery.toc.js
@@ -83,7 +83,7 @@ $.fn.toc = function(options) {
 
       //build TOC item
       var a = $('<a/>')
-      .text($h.text())
+      .text(opts.headerText(i, heading, $h))
       .attr('href', '#' + opts.anchorName(i, heading, opts.prefix))
       .bind('click', scrollTo);
 
@@ -108,6 +108,9 @@ jQuery.fn.toc.defaults = {
   highlightOffset: 100,
   anchorName: function(i, heading, prefix) {
     return prefix+i;
+  },
+  headerText: function(i, heading, $h) {
+    return $h.text();
   } 
 };
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -33,6 +33,9 @@ Defaults shown below
 		'highlightOffset': 100, //offset to trigger the next headline
 		'anchorName': function(i, heading, prefix) { //custom function for anchor name
 			return prefix+i;
+		},
+		'headerText': function(i, heading, $heading) { // custom function building the header-item text
+			return $heading.text();
 		} 
 	});
 


### PR DESCRIPTION
extends the plugin with the new option "headerText" (function callback)
so that we can customize the header text (default is still $h.text())

I've attached the changes of the source code and an addition to the documentation. There is still missing the update of the minified version, a changelog entry and perhaps an example case.
