### PR TITLE
Added callback for when a new section is highlighted

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -29,6 +29,8 @@ Defaults shown below
 		'container': 'body', //element to find all selectors in
 		'smoothScrolling': true, //enable or disable smooth scrolling on click
 		'prefix': 'toc', //prefix for anchor tags and class names
+        'onHighlight': function(el) {}, // When a new section is highlighted, this function 
+                                        // is called and passed the newly highlighted element
 		'highlightOnScroll': true, //add class to heading that is currently in focus
 		'highlightOffset': 100, //offset to trigger the next headline
 		'anchorName': function(i, heading, prefix) { //custom function for anchor name

--- a/lib/toc.js
+++ b/lib/toc.js
@@ -48,11 +48,13 @@ $.fn.toc = function(options) {
       clearTimeout(timeout);
     }
     timeout = setTimeout(function() {
-      var top = $(window).scrollTop();
+      var top = $(window).scrollTop(),
+        highlighted;
       for (var i = 0, c = headingOffsets.length; i < c; i++) {
         if (headingOffsets[i] >= top) {
           $('li', self).removeClass(activeClassName);
-          $('li:eq('+(i-1)+')', self).addClass(activeClassName);
+          highlighted = $('li:eq('+(i-1)+')', self).addClass(activeClassName);
+          opts.onHighlight(highlighted);
           break;
         }
       }
@@ -99,6 +101,7 @@ jQuery.fn.toc.defaults = {
   selectors: 'h1,h2,h3',
   smoothScrolling: true,
   prefix: 'toc',
+  onHighlighted: function() {},
   highlightOnScroll: true,
   highlightOffset: 100,
   anchorName: function(i, heading, prefix) {


### PR DESCRIPTION
My table of contents was taller than the page, so when I scrolled far enough down I could no longer see the active TOC section. This change adds a callback for when the highlighted element changes, and is passed the newly highlighted element. In my case, I am using the scrollintoview plugin [1] to make the section visible.

[1] https://github.com/litera/jquery-scrollintoview
