### PR TITLE
add offset, hash options, and refactor headings process

### DIFF
--- a/lib/toc.js
+++ b/lib/toc.js
@@ -33,8 +33,9 @@ $.fn.toc = function(options) {
       var elScrollTo = $(e.target).attr('href');
       var $el = $(elScrollTo);
       
-      scrollable.animate({ scrollTop: $el.offset().top }, 400, 'swing', function() {
-        location.hash = elScrollTo;
+      scrollable.animate({ scrollTop: $el.offset().top - opts.offset }, 1100, 'swing', function() {
+        if (opts.hash)
+            location.hash = elScrollTo;
       });
     }
     $('li', self).removeClass(activeClassName);
@@ -48,13 +49,15 @@ $.fn.toc = function(options) {
       clearTimeout(timeout);
     }
     timeout = setTimeout(function() {
-      var top = $(window).scrollTop(),
+    
+      var top = $(window).scrollTop() - opts.offset,
         highlighted;
-      for (var i = 0, c = headingOffsets.length; i < c; i++) {
-        if (headingOffsets[i] >= top) {
+      for (var i = 0, c = headings.length; i < c; i++) {
+        if ($(headings[i]).offset().top - opts.offset >= top) {
           $('li', self).removeClass(activeClassName);
-          highlighted = $('li:eq('+(i-1)+')', self).addClass(activeClassName);
-          opts.onHighlight(highlighted);
+          highlighted = $('li:eq('+(i)+')', self).addClass(activeClassName);
+          if (opts.onHighlight)
+            opts.onHighlight(highlighted);
           break;
         }
       }
@@ -71,7 +74,7 @@ $.fn.toc = function(options) {
     var ul = $('<ul/>');
     headings.each(function(i, heading) {
       var $h = $(heading);
-      headingOffsets.push($h.offset().top - opts.highlightOffset);
+      headingOffsets.push($h.offset().top - opts.offset - opts.highlightOffset);
 
       //add anchor
       var anchor = $('<span/>').attr('id', opts.anchorName(i, heading, opts.prefix)).insertBefore($h);
@@ -101,6 +104,8 @@ jQuery.fn.toc.defaults = {
   selectors: 'h1,h2,h3',
   smoothScrolling: true,
   prefix: 'toc',
+  offset: 0,
+  hash: false,
   onHighlighted: function() {},
   highlightOnScroll: true,
   highlightOffset: 100,


### PR DESCRIPTION
1. Add offset option, sometimes the top position is not from 0, so this option can set the offset value from the top.
2. Add hash option, default is false, so that user can disable hashchange process.
3. Refactor headings process. Originally it'll save the headings positions at the initialization phrase, and after refacotring, it'll calulate immediately.
