### PR TITLE
Add headerText and itemClass options

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -37,7 +37,10 @@ Defaults shown below
 		},
 		'headerText': function(i, heading, $heading) { //custom function building the header-item text
 			return $heading.text();
-		} 
+		},
+    'itemClass': function(i, heading, $heading, prefix) { // custom function for item class
+      return $heading[0].tagName.toLowerCase();
+    }
 	});
 
 ##Example CSS

--- a/lib/toc.js
+++ b/lib/toc.js
@@ -78,7 +78,7 @@ $.fn.toc = function(options) {
 
       //build TOC item
       var a = $('<a/>')
-      .text($h.text())
+      .text(opts.headerText(i, heading, $h))
       .attr('href', '#' + opts.anchorName(i, heading, opts.prefix))
       .bind('click', function(e) { 
         scrollTo(e);
@@ -86,7 +86,7 @@ $.fn.toc = function(options) {
       });
 
       var li = $('<li/>')
-      .addClass(opts.prefix+'-'+$h[0].tagName.toLowerCase())
+      .addClass(opts.itemClass(i, heading, $h, opts.prefix))
       .append(a);
 
       ul.append(li);
@@ -106,6 +106,13 @@ jQuery.fn.toc.defaults = {
   highlightOffset: 100,
   anchorName: function(i, heading, prefix) {
     return prefix+i;
+  },
+  headerText: function(i, heading, $heading) {
+    return $heading.text();
+  },
+  itemClass: function(i, heading, $heading, prefix) {
+    console.log('Prefix', prefix);
+    return prefix + '-' + $heading[0].tagName.toLowerCase();
   }
 
 };


### PR DESCRIPTION
1. headerText() was in the docs, but not the code. I needed it, so I added it.
2. I also needed a way to specify the item class, so I added itemClass()– I was using fieldset legends as headers, and that didn't allow me a way to specify a hierarchy. By making it a callback I can set data attributes on the legend and use those in the class instead of the tag name.
