### PR TITLE
Only insert anchor if id doesn't exist

### DIFF
--- a/lib/toc.js
+++ b/lib/toc.js
@@ -73,13 +73,16 @@ $.fn.toc = function(options) {
       var $h = $(heading);
       headingOffsets.push($h.offset().top - opts.highlightOffset);
 
-      //add anchor
-      var anchor = $('<span/>').attr('id', opts.anchorName(i, heading, opts.prefix)).insertBefore($h);
+      // add anchor if id doesn't already exist
+      var anchorId = opts.anchorName(i, heading, opts.prefix);
+      if(!$('#' + anchorId).length) {
+        $('<span/>').attr('id', anchorId).insertBefore($h);
+      }
 
       //build TOC item
       var a = $('<a/>')
         .text(opts.headerText(i, heading, $h))
-        .attr('href', '#' + opts.anchorName(i, heading, opts.prefix))
+        .attr('href', '#' + anchorId)
         .bind('click', function(e) { 
           scrollTo(e);
           el.trigger('selected', $(this).attr('href'));


### PR DESCRIPTION
If my h1's already have id's and I want to use them as the anchorNames instead of #toc1, #toc2, etc, then we need to not insert a new element with the same id.

(I wasn't able to do the full build process. I did 'make install' but then there was no ./node_modules so I'm not sure where it installed smoosh.)
