### PR TITLE
Fixed Uncaught Error for negative scroll height.

### DIFF
--- a/lib/toc.js
+++ b/lib/toc.js
@@ -1,3 +1,10 @@
+/*!
+ * toc - jQuery Table of Contents Plugin
+ * v0.1.2
+ * http://projects.jga.me/toc/
+ * copyright Greg Allen 2013
+ * MIT License
+*/
 (function($) {
 $.fn.toc = function(options) {
   var self = this;
@@ -30,11 +37,13 @@ $.fn.toc = function(options) {
     }
     timeout = setTimeout(function() {
       var top = $(window).scrollTop(),
-        highlighted;
+        highlighted,
+        itemIndex;
       for (var i = 0, c = headingOffsets.length; i < c; i++) {
         if (headingOffsets[i] >= top) {
           $('li', self).removeClass(activeClassName);
-          highlighted = $('li:eq('+(i-1)+')', self).addClass(activeClassName);
+          itemIndex = (i-1 < 0) ? 0 : (i-1);
+          highlighted = $('li:eq('+itemIndex+')', self).addClass(activeClassName);
           opts.onHighlight(highlighted);
           break;
         }


### PR DESCRIPTION
I was having an issue where TOC was causing the following error when the scroll-height of the page was negative relative to the top of the TOC sidebar from the line changed in this PR:

```
Uncaught Error: Syntax error, unrecognized expression: (-1) 
```

At first you might think, the TOC sidebar is fixed at the top of the page, when would the relative scroll-height ever be negative?

The answer is, we have the sidebar further down the page under the heading, and it only becomes fixed when you scroll down to it, so you can scroll up above the sidebar.

But that actually doesn't matter, because this can also happen in both OSX and iOS, where the browsers have a sort of "pulling" effect at the top of the page (where you can continue scrolling up above the page and it makes it look like you're pulling against the top of the page where you can see a gray textured background), and yes JavaScript actually reports a negative scrollTop position when this happens.

In most of the browsers, this doesn't matter incredibly much, it just outputs an Uncaught Error to the console and continues working once you've gone back to a positive relative scroll position. However, for our first example, where the sidebar is further down the page, it actually causes ugly modal error popups in IE7 and IE8.

So this fixes all that.
