### PR TITLE
fixed bug where headingOffsets went out-of-sync on window resize

### DIFF
--- a/lib/toc.js
+++ b/lib/toc.js
@@ -50,18 +50,19 @@ $.fn.toc = function(options) {
       }
     }
   }, 50);
-  if (opts.highlightOnScroll) {
-    $(window).bind('scroll', highlightOnScroll);
-    highlightOnScroll();
-  }
   var recalculateOffsets = debounce(function() {
     headingOffsets.length = 0;
     headings.each(function(i, heading) {
-        var $h = $(heading);
+      var $h = $(heading);
         headingOffsets.push($h.offset().top - opts.highlightOffset);
     });
   }, 50);
-  $(window).bind('orientationchange resize', recalculateOffsets);
+  if (opts.highlightOnScroll) {
+    $(window).bind('scroll', highlightOnScroll);
+    $(window).bind('orientationchange resize', recalculateOffsets);
+    
+    highlightOnScroll();
+  }
 
   return this.each(function() {
     //build TOC
@@ -69,7 +70,9 @@ $.fn.toc = function(options) {
     var ul = $('<ul/>');
     headings.each(function(i, heading) {
       var $h = $(heading);
-      headingOffsets.push($h.offset().top - opts.highlightOffset);
+      if (opts.highlightOnScroll) {
+        headingOffsets.push($h.offset().top - opts.highlightOffset);
+      }
 
       //add anchor
       var anchor = $('<span/>').attr('id', opts.anchorName(i, heading, opts.prefix)).insertBefore($h);


### PR DESCRIPTION
When the window is resized (or orientation of the screen is changed), the content-flow may completly change the heading offsets. These should be recalculated then. 
