### PR TITLE
3 small fixes

### DIFF
--- a/lib/toc.js
+++ b/lib/toc.js
@@ -9,7 +9,7 @@ $.fn.toc = function(options) {
   var headingOffsets = [];
   var activeClassName = opts.prefix+'-active';
 
-  var scrollTo = function(e) {
+  var scrollTo = function(e, callback) {
     if (opts.smoothScrolling) {
       e.preventDefault();
       var elScrollTo = $(e.target).attr('href');
@@ -17,6 +17,7 @@ $.fn.toc = function(options) {
 
       $('body,html').animate({ scrollTop: $el.offset().top }, 400, 'swing', function() {
         location.hash = elScrollTo;
+        callback();
       });
     }
     $('li', self).removeClass(activeClassName);
@@ -66,8 +67,11 @@ $.fn.toc = function(options) {
       var a = $('<a/>')
         .text(opts.headerText(i, heading, $h))
         .attr('href', '#' + opts.anchorName(i, heading, opts.prefix))
-        .bind('click', function(e) { 
-          scrollTo(e);
+        .bind('click', function(e) {
+          $(window).unbind('scroll', highlightOnScroll);
+          scrollTo(e, function() {
+            $(window).bind('scroll', highlightOnScroll);
+          });
           el.trigger('selected', $(this).attr('href'));
         });
 


### PR DESCRIPTION
3 small fixes to your nice plugin:
- Changed the logic for high lightning to high light the closed header
- Disabled the highlighting when scrolling because of mouse click, making sure the user clicked header will stay selected regardless of the high lighting logic
- Little error syntax error in the default properties

Thanks,
        Erik Jan
