### PR TITLE
Uses defined jQuery variable instead of default jQuery

### DIFF
--- a/lib/toc.js
+++ b/lib/toc.js
@@ -87,7 +87,7 @@ $.fn.toc = function(options) {
 };
 
 
-jQuery.fn.toc.defaults = {
+$.fn.toc.defaults = {
   container: 'body',
   listType: '<ul/>',
   selectors: 'h1,h2,h3',


### PR DESCRIPTION
**Summary of Changes:** 
- Modifies the call to toc.default to use the variable set by the library and not use the default jQuery.

This was needed because our framework uses jQuery 1.7 but the library needs jQuery 1.8+ to scroll correctly. Returned 'default' of undefined because jQuery was storing defaults under the wrong version.
