### PR TITLE
bug fix for named anchors that start with "." such as those made for doc...

### DIFF
--- a/lib/toc.js
+++ b/lib/toc.js
@@ -12,7 +12,7 @@ $.fn.toc = function(options) {
   var scrollTo = function(e, callback) {
     if (opts.smoothScrolling && typeof opts.smoothScrolling === 'function') {
       e.preventDefault();
-      var elScrollTo = $(e.target).attr('href');
+      var elScrollTo = $(e.target).attr('href').replace('#.', '#\\.');
 
       opts.smoothScrolling(elScrollTo, opts, callback);
     }


### PR DESCRIPTION
Same fix I made for docstrap. Should also help with https://github.com/jgallen23/toc/issues/16 if I'm reading that bug correctly