### PR TITLE
Fixes wrong link being highlighted when page length changes dynamically

### DIFF
--- a/lib/toc.js
+++ b/lib/toc.js
@@ -6,8 +6,16 @@ $.fn.toc = function(options) {
 
   var container = $(opts.container);
   var headings = $(opts.selectors, container);
-  var headingOffsets = [];
   var activeClassName = opts.activeClass;
+  
+  var headingOffsets = function() {
+    var offsets = [];
+    headings.each(function(i, heading) {
+      var $h = $(heading);
+      offsets.push($h.offset().top - opts.highlightOffset);
+    });
+    return offsets;
+  }; 
 
   var scrollTo = function(e, callback) {
     if (opts.smoothScrolling && typeof opts.smoothScrolling === 'function') {
@@ -28,10 +36,11 @@ $.fn.toc = function(options) {
     }
     timeout = setTimeout(function() {
       var top = $(window).scrollTop(),
-        highlighted, closest = Number.MAX_VALUE, index = 0;
+        highlighted, closest = Number.MAX_VALUE, index = 0
+        offsets = headingOffsets();
       
-      for (var i = 0, c = headingOffsets.length; i < c; i++) {
-        var currentClosest = Math.abs(headingOffsets[i] - top);
+      for (var i = 0, c = offsets.length; i < c; i++) {
+        var currentClosest = Math.abs(offsets[i] - top);
         if (currentClosest < closest) {
           index = i;
           closest = currentClosest;
@@ -55,7 +64,6 @@ $.fn.toc = function(options) {
 
     headings.each(function(i, heading) {
       var $h = $(heading);
-      headingOffsets.push($h.offset().top - opts.highlightOffset);
 
       var anchorName = opts.anchorName(i, heading, opts.prefix);
 


### PR DESCRIPTION
I have a case where the content underneath each heading is added dynamically so have the heading offsets calculated only on initialization means they will be wrong.  This change just calculates them on the fly.
