### PR TITLE
Change SPAN to A tag with name attr instead of id

### DIFF
--- a/dist/toc.js
+++ b/dist/toc.js
@@ -118,7 +118,7 @@ $.fn.toc = function(options) {
 
       //add anchor
       if(heading.id !== anchorName) {
-        var anchor = $('<span/>').attr('id', anchorName).insertBefore($h);
+        var anchor = $('<a/>').attr('name', anchorName).insertBefore($h);
       }
 
       //build TOC item


### PR DESCRIPTION
Using <span id="xx"> didn't work in IE9. It works when you use an <a> tag, with a name attribute instead of the id. This is also supported in other browsers.