### PR TITLE
add id attr directly in heading if possible

### DIFF
--- a/lib/toc.js
+++ b/lib/toc.js
@@ -61,7 +61,11 @@ $.fn.toc = function(options) {
 
       //add anchor
       if(heading.id !== anchorName) {
-        var anchor = $('<span/>').attr('id', anchorName).insertBefore($h);
+        if (!heading.id) {
+          heading.id = anchorName;
+        } else {
+          var anchor = $('<span/>').attr('id', anchorName).insertBefore($h);
+        }
       }
 
       //build TOC item


### PR DESCRIPTION
Instead of generating a useless <span id="..."> before the relevant
<h?> tag, just add the id attr to the <h?> tag if it does not have
one already.

This way, the target of the link is exactly the <h?> tag, and the
browser positions the focus exactly on it. Without this, there was a
slight difference in offset between tags which had an id= attr an
tags which didn't.