### PR TITLE
Sanitize dict elements class name

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,8 +28,8 @@ function init(el) {
       // Keep the id if already there
       const index = item.id || `toc-${i++}`;
       const text = item.dataset.tocTitle ?
-        item.dataset.tocTitle.trim() : item.textContent.trim();
-      const sanitizedClassName = selector.replace(/((:+[\w-\d]*)|[^A-z0-9-\s])/g, '').replace(/\s{2,}/g, '').trim();
+      item.dataset.tocTitle.trim() : item.textContent.trim();
+      const sanitizedClassName = selector.replace(/((:+[\w-\d]*)|[^A-z0-9-\s])/g, ' ').replace(/\s{2,}/g, ' ').trim();
       const className = `toc-${sanitizedClassName}`;
 
       // Set it if none

--- a/index.js
+++ b/index.js
@@ -29,7 +29,8 @@ function init(el) {
       const index = item.id || `toc-${i++}`;
       const text = item.dataset.tocTitle ?
         item.dataset.tocTitle.trim() : item.textContent.trim();
-      const className = `toc-${selector}`;
+      const sanitizedClassName = selector.replace(/((:+[\w-\d]*)|[^A-z0-9-\s])/g, '').replace(/\s{2,}/g, '').trim();
+      const className = `toc-${sanitizedClassName}`;
 
       // Set it if none
       if (item.id !== index) {

--- a/package.json
+++ b/package.json
@@ -27,13 +27,13 @@
   },
   "homepage": "https://github.com/jgallen23/toc#readme",
   "devDependencies": {
-    "eslint-config-firstandthird": "3.2.0",
-    "eslint-plugin-import": "2.2.0",
-    "phantomjs-prebuilt": "2.1.14",
-    "scriptkit": "0.2.0",
+    "eslint-config-firstandthird": "4.0.1",
+    "eslint-plugin-import": "2.8.0",
+    "phantomjs-prebuilt": "2.1.16",
+    "scriptkit": "0.3.0",
     "tap-spec": "4.1.1",
     "tape-rollup": "4.6.4",
-    "tape-run": "2.2.0"
+    "tape-run": "3.0.0"
   },
   "eslintConfig": {
     "env": {

--- a/test/toc.test.js
+++ b/test/toc.test.js
@@ -11,10 +11,10 @@ const setup = () => {
   const container = document.getElementById('fixture');
   container.innerHTML = `
     <div id="wrapper">
-      <div class="toc" data-toc="h1, h2, h3, #last-heading"></div>
+      <div class="toc" data-toc="h1.page-title, h2, #last, #last-heading"></div>
     </div>
     <div id="content_wrapper">
-      <h1>Page Title</h1>
+      <h1 class="page-title">Page Title</h1>
       <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum fermentum ligula a augue sollicitudin a tincidunt felis tincidunt. Donec et urna augue, sed consectetur lacus. Maecenas tincidunt volutpat lorem. Suspendisse turpis tellus, sodales ac commodo id, rhoncus vel augue. Vestibulum nisl nibh, rutrum eu bibendum vitae, bibendum et libero. Suspendisse vel odio vitae leo commodo lacinia. Sed non lacinia nulla. Pellentesque faucibus euismod dictum. Suspendisse potenti.</p>
       <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum fermentum ligula a augue sollicitudin a tincidunt felis tincidunt. Donec et urna augue, sed consectetur lacus. Maecenas tincidunt volutpat lorem. Suspendisse turpis tellus, sodales ac commodo id, rhoncus vel augue. Vestibulum nisl nibh, rutrum eu bibendum vitae, bibendum et libero. Suspendisse vel odio vitae leo commodo lacinia. Sed non lacinia nulla. Pellentesque faucibus euismod dictum. Suspendisse potenti.</p>
       <h2>Sub Heading</h2>
@@ -62,10 +62,12 @@ test('anchor formatting', assert => {
 test('links', assert => {
   const container = setup();
 
-  assert.equal(container.querySelectorAll('a').length, 6, 'should have links');
+  assert.equal(container.querySelectorAll('a').length, 5, 'should have links');
   assert.equal(container.querySelectorAll('a')[3].textContent, container.querySelector('h3').dataset.tocTitle, 'should use data-toc-title if available');
   assert.equal(container.querySelectorAll('a')[0].textContent, container.querySelector('h1').textContent, 'should use text otherwise');
-  assert.ok(container.querySelectorAll('a')[4].classList.contains('toc-last-heading'), 'should have a class name');
+  assert.ok(container.querySelectorAll('li')[0].classList.contains('page-title'), 'should have "page-title" class');
+  assert.ok(container.querySelectorAll('li')[3].classList.contains('toc-last'), 'should have "toc-last" class');
+  assert.ok(container.querySelectorAll('li')[4].classList.contains('toc-last-heading'), 'should have "toc-last-heading" class');
   assert.end();
 });
 

--- a/test/toc.test.js
+++ b/test/toc.test.js
@@ -11,7 +11,7 @@ const setup = () => {
   const container = document.getElementById('fixture');
   container.innerHTML = `
     <div id="wrapper">
-      <div class="toc" data-toc="h1, h2, h3"></div>
+      <div class="toc" data-toc="h1, h2, h3, #last-heading"></div>
     </div>
     <div id="content_wrapper">
       <h1>Page Title</h1>
@@ -26,6 +26,10 @@ const setup = () => {
       <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum fermentum ligula a augue sollicitudin a tincidunt felis tincidunt. Donec et urna augue, sed consectetur lacus. Maecenas tincidunt volutpat lorem. Suspendisse turpis tellus, sodales ac commodo id, rhoncus vel augue. Vestibulum nisl nibh, rutrum eu bibendum vitae, bibendum et libero. Suspendisse vel odio vitae leo commodo lacinia. Sed non lacinia nulla. Pellentesque faucibus euismod dictum. Suspendisse potenti.</p>
       <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum fermentum ligula a augue sollicitudin a tincidunt felis tincidunt. Donec et urna augue, sed consectetur lacus. Maecenas tincidunt volutpat lorem. Suspendisse turpis tellus, sodales ac commodo id, rhoncus vel augue. Vestibulum nisl nibh, rutrum eu bibendum vitae, bibendum et libero. Suspendisse vel odio vitae leo commodo lacinia. Sed non lacinia nulla. Pellentesque faucibus euismod dictum. Suspendisse potenti.</p>
       <h3 id="last" data-toc-title="Custom subsub-heading">SubSub Heading</h3>
+      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum fermentum ligula a augue sollicitudin a tincidunt felis tincidunt. Donec et urna augue, sed consectetur lacus. Maecenas tincidunt volutpat lorem. Suspendisse turpis tellus, sodales ac commodo id, rhoncus vel augue. Vestibulum nisl nibh, rutrum eu bibendum vitae, bibendum et libero. Suspendisse vel odio vitae leo commodo lacinia. Sed non lacinia nulla. Pellentesque faucibus euismod dictum. Suspendisse potenti.</p>
+      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum fermentum ligula a augue sollicitudin a tincidunt felis tincidunt. Donec et urna augue, sed consectetur lacus. Maecenas tincidunt volutpat lorem. Suspendisse turpis tellus, sodales ac commodo id, rhoncus vel augue. Vestibulum nisl nibh, rutrum eu bibendum vitae, bibendum et libero. Suspendisse vel odio vitae leo commodo lacinia. Sed non lacinia nulla. Pellentesque faucibus euismod dictum. Suspendisse potenti.</p>
+      <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum fermentum ligula a augue sollicitudin a tincidunt felis tincidunt. Donec et urna augue, sed consectetur lacus. Maecenas tincidunt volutpat lorem. Suspendisse turpis tellus, sodales ac commodo id, rhoncus vel augue. Vestibulum nisl nibh, rutrum eu bibendum vitae, bibendum et libero. Suspendisse vel odio vitae leo commodo lacinia. Sed non lacinia nulla. Pellentesque faucibus euismod dictum. Suspendisse potenti.</p>
+      <h3 id="last-heading">Last heading</h3>
       <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum fermentum ligula a augue sollicitudin a tincidunt felis tincidunt. Donec et urna augue, sed consectetur lacus. Maecenas tincidunt volutpat lorem. Suspendisse turpis tellus, sodales ac commodo id, rhoncus vel augue. Vestibulum nisl nibh, rutrum eu bibendum vitae, bibendum et libero. Suspendisse vel odio vitae leo commodo lacinia. Sed non lacinia nulla. Pellentesque faucibus euismod dictum. Suspendisse potenti.</p>
       <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum fermentum ligula a augue sollicitudin a tincidunt felis tincidunt. Donec et urna augue, sed consectetur lacus. Maecenas tincidunt volutpat lorem. Suspendisse turpis tellus, sodales ac commodo id, rhoncus vel augue. Vestibulum nisl nibh, rutrum eu bibendum vitae, bibendum et libero. Suspendisse vel odio vitae leo commodo lacinia. Sed non lacinia nulla. Pellentesque faucibus euismod dictum. Suspendisse potenti.</p>
       <p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vestibulum fermentum ligula a augue sollicitudin a tincidunt felis tincidunt. Donec et urna augue, sed consectetur lacus. Maecenas tincidunt volutpat lorem. Suspendisse turpis tellus, sodales ac commodo id, rhoncus vel augue. Vestibulum nisl nibh, rutrum eu bibendum vitae, bibendum et libero. Suspendisse vel odio vitae leo commodo lacinia. Sed non lacinia nulla. Pellentesque faucibus euismod dictum. Suspendisse potenti.</p>
@@ -58,9 +62,10 @@ test('anchor formatting', assert => {
 test('links', assert => {
   const container = setup();
 
-  assert.equal(container.querySelectorAll('a').length, 4, 'should have links');
+  assert.equal(container.querySelectorAll('a').length, 6, 'should have links');
   assert.equal(container.querySelectorAll('a')[3].textContent, container.querySelector('h3').dataset.tocTitle, 'should use data-toc-title if available');
   assert.equal(container.querySelectorAll('a')[0].textContent, container.querySelector('h1').textContent, 'should use text otherwise');
+  assert.ok(container.querySelectorAll('a')[4].classList.contains('toc-last-heading'), 'should have a class name');
   assert.end();
 });
 


### PR DESCRIPTION
When dict links are generated, `data-toc` selectors are used in the dict element class name keeping special chars such as dots. See example below.

![screenshot_2017-11-09_at_9 12 18_am](https://user-images.githubusercontent.com/5501685/32960783-7e658a02-cbc6-11e7-9c7a-aa1259071d9a.png)

I have added a replace regex to fix that. Here is a screenshot of a test:

<img width="475" alt="screen shot 2017-11-20 at 11 01 13" src="https://user-images.githubusercontent.com/5501685/33012779-3419b32e-cde2-11e7-92e5-034ee3b49c4d.png">

Thanks!